### PR TITLE
Adiciona notebooks de ingestão e DAG de regime tributário

### DIFF
--- a/src/dags/rfb/regime_tributario/rfb_regime_tributario.py
+++ b/src/dags/rfb/regime_tributario/rfb_regime_tributario.py
@@ -1,0 +1,77 @@
+import os
+import pendulum
+
+from airflow.sdk import dag
+
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def rbf_regime_tributario():
+
+    landing_rbf_regime_tributario_imunes_isentas = PapermillOperator(
+        task_id="landing_rbf_regime_tributario_imunes_isentas",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_rbf_regime_tributario_imunes_isentas.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_rbf_regime_tributario_imunes_isentas_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+    landing_rbf_regime_tributario_lucro_arbitrado = PapermillOperator(
+        task_id="landing_rbf_regime_tributario_lucro_arbitrado",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_rbf_cnpj_regime_tributario_lucro_arbitrado",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_rbf_regime_tributario_lucro_arbitrado_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+    landing_rbf_regime_tributario_lucro_presumido = PapermillOperator(
+        task_id="landing_rbf_regime_tributario_lucro_presumido",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_rbf_regime_tributario_lucro_presumido.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_rbf_regime_tributario_lucro_presumido_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+    landing_rbf_regime_tributario_lucro_real = PapermillOperator(
+        task_id="landing_rbf_regime_tributario_lucro_real",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_rbf_regime_tributario_lucro_real.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_rbf_regime_tributario_lucro_real_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+
+
+    landing_rbf_regime_tributario_imunes_isentas.set_downstream(landing_rbf_regime_tributario_lucro_arbitrado)
+    landing_rbf_regime_tributario_lucro_arbitrado.set_downstream(landing_rbf_regime_tributario_lucro_presumido)
+    landing_rbf_regime_tributario_lucro_presumido.set_downstream(landing_rbf_regime_tributario_lucro_real)
+  
+
+rbf_regime_tributario()

--- a/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_imunes_isentas.ipynb
+++ b/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_imunes_isentas.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acd7da26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import logging\n",
+    "import zipfile\n",
+    "from typing import List\n",
+    "import requests\n",
+    "from urllib.parse import quote\n",
+    "\n",
+    "from minio import Minio\n",
+    "from pathlib import Path\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "53dbf7d0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0f4dc877",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0bd433da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open(\"../variables/minio_connection.json\", \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0a9e1f77",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:13:10,616 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e618ee54",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:13:10,628 - INFO - Pasta de download criada: download\n"
+     ]
+    }
+   ],
+   "source": [
+    "url = \"https://arquivos.receitafederal.gov.br/dados/cnpj/regime_tributario/\"\n",
+    "bucket = \"landing\"\n",
+    "schema = \"rfb\"\n",
+    "table = \"regime_tributario_imunes_isentas\"\n",
+    "\n",
+    "archives = [\n",
+    "    \"Imunes e Isentas.zip\",\n",
+    "]\n",
+    "\n",
+    "# Pasta de staging\n",
+    "download_path = Path(\"download\")\n",
+    "download_path.mkdir(parents=True, exist_ok=True)\n",
+    "logger.info(f\"Pasta de download criada: {download_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f1f75cbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_and_extract(url: str, download_path: Path, retries: int = 3) -> None:\n",
+    "    filename = url.split(\"/\")[-1]\n",
+    "    path_file = download_path / filename\n",
+    "\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            response = requests.get(url, stream=True, timeout=600)\n",
+    "            status = response.status_code\n",
+    "\n",
+    "            if status != 200:\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Status inesperado\")\n",
+    "                return\n",
+    "\n",
+    "            content_type = response.headers.get(\"Content-Type\")\n",
+    "            if content_type != \"application/zip\":\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Tipo inesperado: {content_type}\")\n",
+    "                return\n",
+    "\n",
+    "            content_length = response.headers.get(\"Content-Length\")\n",
+    "            if content_length is None or int(content_length) == 0:\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Tamanho indefinido ou inesperado\")\n",
+    "                return\n",
+    "\n",
+    "            # Download\n",
+    "            with open(path_file, \"wb\") as f:\n",
+    "                for chunk in response.iter_content(chunk_size=1024*1024):\n",
+    "                    f.write(chunk)\n",
+    "            logger.info(f\"Baixado: {filename}\")\n",
+    "\n",
+    "            # Extração\n",
+    "            try:\n",
+    "                with zipfile.ZipFile(path_file, \"r\") as zf:\n",
+    "                    zf.extractall(download_path)\n",
+    "                logger.info(f\"Extraído: {filename}\")\n",
+    "            except zipfile.BadZipFile as bz:\n",
+    "                logger.error(f\"Url: {url}, Error: {bz}, Message: Erro ao tentar descompactar o arquivo: {filename}\")\n",
+    "            return  # sucesso\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "    logger.error(f\"Falha ao baixar {url} após {retries} tentativas\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5bdb9c2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:13:18,694 - INFO - Baixado: Imunes%20e%20Isentas.zip\n",
+      "2025-08-22 14:13:18,970 - INFO - Extraído: Imunes%20e%20Isentas.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "for arquivo in archives:\n",
+    "    file_url = url + quote(arquivo) \n",
+    "    download_and_extract(file_url, download_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4adb74f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uploud para MinIO\n",
+    "arquivos_para_uploud = list(download_path.rglob(\"*.csv\"))\n",
+    "\n",
+    "for arquivo in arquivos_para_uploud:\n",
+    "    caminho_relativo = arquivo.relative_to(download_path)\n",
+    "    destino = f\"rfb/regime_tributario/imunes_isentas/{caminho_relativo.as_posix()}\"\n",
+    "    s3_client.fput_object(\n",
+    "        bucket_name=\"landing\",\n",
+    "        object_name=destino,\n",
+    "        file_path=str(arquivo)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1bc6ddda",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:13:19,340 - INFO - Pasta 'download' removida com sucesso após upload.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Limpeza da pasta download após upload\n",
+    "downloads_path = Path(\"download\")\n",
+    "try:\n",
+    "    if downloads_path.exists():\n",
+    "        shutil.rmtree(downloads_path)\n",
+    "        logger.info(f\"Pasta '{downloads_path}' removida com sucesso após upload.\")\n",
+    "    else:\n",
+    "        logger.warning(f\"Pasta '{downloads_path}' não encontrada para remoção.\")\n",
+    "except Exception as e:\n",
+    "    logger.error(f\"Erro ao tentar remover '{downloads_path}': {e}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_arbitrado.ipynb
+++ b/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_arbitrado.ipynb
@@ -1,0 +1,276 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acd7da26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import logging\n",
+    "import zipfile\n",
+    "from typing import List\n",
+    "import requests\n",
+    "from urllib.parse import quote\n",
+    "\n",
+    "from minio import Minio\n",
+    "from pathlib import Path\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "53dbf7d0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0f4dc877",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0bd433da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open(\"../variables/minio_connection.json\", \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0a9e1f77",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:11:57,515 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e618ee54",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:11:57,529 - INFO - Pasta de download criada: download\n"
+     ]
+    }
+   ],
+   "source": [
+    "url = \"https://arquivos.receitafederal.gov.br/dados/cnpj/regime_tributario/\"\n",
+    "bucket = \"landing\"\n",
+    "schema = \"rfb\"\n",
+    "table = \"regime_tributario_lucro_arbitrado\"\n",
+    "\n",
+    "archives = [\n",
+    "   \"Lucro Arbitrado.zip\"\n",
+    "]\n",
+    "\n",
+    "# Pasta de staging\n",
+    "download_path = Path(\"download\")\n",
+    "download_path.mkdir(parents=True, exist_ok=True)\n",
+    "logger.info(f\"Pasta de download criada: {download_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f1f75cbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_and_extract(url: str, download_path: Path, retries: int = 3) -> None:\n",
+    "    filename = url.split(\"/\")[-1]\n",
+    "    path_file = download_path / filename\n",
+    "\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            response = requests.get(url, stream=True, timeout=600)\n",
+    "            status = response.status_code\n",
+    "\n",
+    "            if status != 200:\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Status inesperado\")\n",
+    "                return\n",
+    "\n",
+    "            content_type = response.headers.get(\"Content-Type\")\n",
+    "            if content_type != \"application/zip\":\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Tipo inesperado: {content_type}\")\n",
+    "                return\n",
+    "\n",
+    "            content_length = response.headers.get(\"Content-Length\")\n",
+    "            if content_length is None or int(content_length) == 0:\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Tamanho indefinido ou inesperado\")\n",
+    "                return\n",
+    "\n",
+    "            # Download\n",
+    "            with open(path_file, \"wb\") as f:\n",
+    "                for chunk in response.iter_content(chunk_size=1024*1024):\n",
+    "                    f.write(chunk)\n",
+    "            logger.info(f\"Baixado: {filename}\")\n",
+    "\n",
+    "            # Extração\n",
+    "            try:\n",
+    "                with zipfile.ZipFile(path_file, \"r\") as zf:\n",
+    "                    zf.extractall(download_path)\n",
+    "                logger.info(f\"Extraído: {filename}\")\n",
+    "            except zipfile.BadZipFile as bz:\n",
+    "                logger.error(f\"Url: {url}, Error: {bz}, Message: Erro ao tentar descompactar o arquivo: {filename}\")\n",
+    "            return  # sucesso\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "    logger.error(f\"Falha ao baixar {url} após {retries} tentativas\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5bdb9c2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:11:58,038 - INFO - Baixado: Lucro%20Arbitrado.zip\n",
+      "2025-08-22 14:11:58,042 - INFO - Extraído: Lucro%20Arbitrado.zip\n",
+      "2025-08-22 14:11:58,042 - INFO - Extraído: Lucro%20Arbitrado.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "for arquivo in archives:\n",
+    "    file_url = url + quote(arquivo) \n",
+    "    download_and_extract(file_url, download_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4adb74f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uploud para MinIO\n",
+    "arquivos_para_uploud = list(download_path.rglob(\"*.csv\"))\n",
+    "\n",
+    "for arquivo in arquivos_para_uploud:\n",
+    "    caminho_relativo = arquivo.relative_to(download_path)\n",
+    "    destino = f\"rfb/regime_tributario/lucro_arbitrado/{caminho_relativo.as_posix()}\"\n",
+    "    s3_client.fput_object(\n",
+    "        bucket_name=\"landing\",\n",
+    "        object_name=destino,\n",
+    "        file_path=str(arquivo)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "4164b2b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:11:58,082 - INFO - Pasta 'download' removida com sucesso após upload.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Limpeza da pasta download após upload\n",
+    "downloads_path = Path(\"download\")\n",
+    "try:\n",
+    "    if downloads_path.exists():\n",
+    "        shutil.rmtree(downloads_path)\n",
+    "        logger.info(f\"Pasta '{downloads_path}' removida com sucesso após upload.\")\n",
+    "    else:\n",
+    "        logger.warning(f\"Pasta '{downloads_path}' não encontrada para remoção.\")\n",
+    "except Exception as e:\n",
+    "    logger.error(f\"Erro ao tentar remover '{downloads_path}': {e}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_presumido.ipynb
+++ b/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_presumido.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acd7da26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import logging\n",
+    "import zipfile\n",
+    "from typing import List\n",
+    "import requests\n",
+    "from urllib.parse import quote\n",
+    "\n",
+    "from minio import Minio\n",
+    "from pathlib import Path\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "53dbf7d0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0f4dc877",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0bd433da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open(\"../variables/minio_connection.json\", \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0a9e1f77",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:20:38,597 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e618ee54",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:20:38,615 - INFO - Pasta de download criada: download\n"
+     ]
+    }
+   ],
+   "source": [
+    "url = \"https://arquivos.receitafederal.gov.br/dados/cnpj/regime_tributario/\"\n",
+    "bucket = \"landing\"\n",
+    "schema = \"rfb\"\n",
+    "table = \"regime_tributario_lucro_presumido\"\n",
+    "\n",
+    "archives = [\n",
+    "    \"Lucro Presumido.zip\",\n",
+    "]\n",
+    "\n",
+    "# Pasta de staging\n",
+    "download_path = Path(\"download\")\n",
+    "download_path.mkdir(parents=True, exist_ok=True)\n",
+    "logger.info(f\"Pasta de download criada: {download_path}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f1f75cbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_and_extract(url: str, download_path: Path, retries: int = 3) -> None:\n",
+    "    filename = url.split(\"/\")[-1]\n",
+    "    path_file = download_path / filename\n",
+    "\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            response = requests.get(url, stream=True, timeout=600)\n",
+    "            status = response.status_code\n",
+    "\n",
+    "            if status != 200:\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Status inesperado\")\n",
+    "                return\n",
+    "\n",
+    "            content_type = response.headers.get(\"Content-Type\")\n",
+    "            if content_type != \"application/zip\":\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Tipo inesperado: {content_type}\")\n",
+    "                return\n",
+    "\n",
+    "            content_length = response.headers.get(\"Content-Length\")\n",
+    "            if content_length is None or int(content_length) == 0:\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Tamanho indefinido ou inesperado\")\n",
+    "                return\n",
+    "\n",
+    "            # Download\n",
+    "            with open(path_file, \"wb\") as f:\n",
+    "                for chunk in response.iter_content(chunk_size=1024*1024):\n",
+    "                    f.write(chunk)\n",
+    "            logger.info(f\"Baixado: {filename}\")\n",
+    "\n",
+    "            # Extração\n",
+    "            try:\n",
+    "                with zipfile.ZipFile(path_file, \"r\") as zf:\n",
+    "                    zf.extractall(download_path)\n",
+    "                logger.info(f\"Extraído: {filename}\")\n",
+    "            except zipfile.BadZipFile as bz:\n",
+    "                logger.error(f\"Url: {url}, Error: {bz}, Message: Erro ao tentar descompactar o arquivo: {filename}\")\n",
+    "            return  # sucesso\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "    logger.error(f\"Falha ao baixar {url} após {retries} tentativas\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5bdb9c2f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:21:00,802 - INFO - Baixado: Lucro%20Presumido.zip\n",
+      "2025-08-22 14:21:01,750 - INFO - Extraído: Lucro%20Presumido.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "for arquivo in archives:\n",
+    "    file_url = url + quote(arquivo) \n",
+    "    download_and_extract(file_url, download_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4adb74f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uploud para MinIO\n",
+    "arquivos_para_uploud = list(download_path.rglob(\"*.csv\"))\n",
+    "\n",
+    "for arquivo in arquivos_para_uploud:\n",
+    "    caminho_relativo = arquivo.relative_to(download_path)\n",
+    "    destino = f\"rfb/regime_tributario/lucro_presumido/{caminho_relativo.as_posix()}\"\n",
+    "    s3_client.fput_object(\n",
+    "        bucket_name=\"landing\",\n",
+    "        object_name=destino,\n",
+    "        file_path=str(arquivo)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0f86f255",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:21:03,224 - INFO - Pasta 'download' removida com sucesso após upload.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Limpeza da pasta download após upload\n",
+    "downloads_path = Path(\"download\")\n",
+    "try:\n",
+    "    if downloads_path.exists():\n",
+    "        shutil.rmtree(downloads_path)\n",
+    "        logger.info(f\"Pasta '{downloads_path}' removida com sucesso após upload.\")\n",
+    "    else:\n",
+    "        logger.warning(f\"Pasta '{downloads_path}' não encontrada para remoção.\")\n",
+    "except Exception as e:\n",
+    "    logger.error(f\"Erro ao tentar remover '{downloads_path}': {e}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_real.ipynb
+++ b/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_real.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "acd7da26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import logging\n",
+    "import zipfile\n",
+    "from typing import List\n",
+    "import requests\n",
+    "from urllib.parse import quote\n",
+    "\n",
+    "from minio import Minio\n",
+    "from pathlib import Path\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "53dbf7d0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0f4dc877",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0bd433da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open(\"../variables/minio_connection.json\", \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0a9e1f77",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:25:14,144 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e618ee54",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:25:14,156 - INFO - Pasta de download criada: download\n"
+     ]
+    }
+   ],
+   "source": [
+    "url = \"https://arquivos.receitafederal.gov.br/dados/cnpj/regime_tributario/\"\n",
+    "bucket = \"landing\"\n",
+    "schema = \"rfb\"\n",
+    "table = \"regime_tributario_lucro_real\"\n",
+    "\n",
+    "archives = [\n",
+    "    \"Lucro Real.zip\",\n",
+    "]\n",
+    "\n",
+    "# Pasta de staging\n",
+    "download_path = Path(\"download\")\n",
+    "download_path.mkdir(parents=True, exist_ok=True)\n",
+    "logger.info(f\"Pasta de download criada: {download_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "f1f75cbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_and_extract(url: str, download_path: Path, retries: int = 3) -> None:\n",
+    "    filename = url.split(\"/\")[-1]\n",
+    "    path_file = download_path / filename\n",
+    "\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            response = requests.get(url, stream=True, timeout=600)\n",
+    "            status = response.status_code\n",
+    "\n",
+    "            if status != 200:\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Status inesperado\")\n",
+    "                return\n",
+    "\n",
+    "            content_type = response.headers.get(\"Content-Type\")\n",
+    "            if content_type != \"application/zip\":\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Tipo inesperado: {content_type}\")\n",
+    "                return\n",
+    "\n",
+    "            content_length = response.headers.get(\"Content-Length\")\n",
+    "            if content_length is None or int(content_length) == 0:\n",
+    "                logger.error(f\"Url: {url}, Status: {status}, Message: Tamanho indefinido ou inesperado\")\n",
+    "                return\n",
+    "\n",
+    "            # Download\n",
+    "            with open(path_file, \"wb\") as f:\n",
+    "                for chunk in response.iter_content(chunk_size=1024*1024):\n",
+    "                    f.write(chunk)\n",
+    "            logger.info(f\"Baixado: {filename}\")\n",
+    "\n",
+    "            # Extração\n",
+    "            try:\n",
+    "                with zipfile.ZipFile(path_file, \"r\") as zf:\n",
+    "                    zf.extractall(download_path)\n",
+    "                logger.info(f\"Extraído: {filename}\")\n",
+    "            except zipfile.BadZipFile as bz:\n",
+    "                logger.error(f\"Url: {url}, Error: {bz}, Message: Erro ao tentar descompactar o arquivo: {filename}\")\n",
+    "            return  # sucesso\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "    logger.error(f\"Falha ao baixar {url} após {retries} tentativas\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4adb74f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:25:22,023 - INFO - Baixado: Lucro%20Real.zip\n",
+      "2025-08-22 14:25:22,248 - INFO - Extraído: Lucro%20Real.zip\n"
+     ]
+    }
+   ],
+   "source": [
+    "for arquivo in archives:\n",
+    "    file_url = url + quote(arquivo) \n",
+    "    download_and_extract(file_url, download_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "a3681a6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uploud para MinIO\n",
+    "arquivos_para_uploud = list(download_path.rglob(\"*.csv\"))\n",
+    "\n",
+    "for arquivo in arquivos_para_uploud:\n",
+    "    caminho_relativo = arquivo.relative_to(download_path)\n",
+    "    destino = f\"rfb/regime_tributario/lucro_real/{caminho_relativo.as_posix()}\"\n",
+    "    s3_client.fput_object(\n",
+    "        bucket_name=\"landing\",\n",
+    "        object_name=destino,\n",
+    "        file_path=str(arquivo)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1bc6ddda",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-22 14:25:22,564 - INFO - Pasta 'download' removida com sucesso após upload.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Limpeza da pasta download após upload\n",
+    "downloads_path = Path(\"download\")\n",
+    "try:\n",
+    "    if downloads_path.exists():\n",
+    "        shutil.rmtree(downloads_path)\n",
+    "        logger.info(f\"Pasta '{downloads_path}' removida com sucesso após upload.\")\n",
+    "    else:\n",
+    "        logger.warning(f\"Pasta '{downloads_path}' não encontrada para remoção.\")\n",
+    "except Exception as e:\n",
+    "    logger.error(f\"Erro ao tentar remover '{downloads_path}': {e}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Este PR adiciona os notebooks responsáveis pela ingestão dos dados de regime tributário na camada landing, contemplando os diferentes tipos (imunes_isentas, lucro_arbitrado, lucro_presumido e lucro_real).
Além disso, foi criada a DAG no Airflow para orquestração das tasks.