### PR TITLE
feat: ajustar pipeline para ler apenas CSVs ignorando subpastas

### DIFF
--- a/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_presumido.ipynb
+++ b/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_presumido.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "acd7da26",
+   "id": "eac6017d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 14:20:38,597 - INFO - Cliente MinIO criado com sucesso.\n"
+      "2025-08-26 10:19:59,784 - INFO - Cliente MinIO criado com sucesso.\n"
      ]
     }
    ],
@@ -112,7 +112,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 14:20:38,615 - INFO - Pasta de download criada: download\n"
+      "2025-08-26 10:19:59,797 - INFO - Pasta de download criada: download\n"
      ]
     }
    ],
@@ -171,7 +171,12 @@
     "            # Extração\n",
     "            try:\n",
     "                with zipfile.ZipFile(path_file, \"r\") as zf:\n",
-    "                    zf.extractall(download_path)\n",
+    "                    for member in zf.infolist():\n",
+    "                        if member.filename.endswith(\".csv\"):\n",
+    "                            target_path = download_path / Path(member.filename).name\n",
+    "                            zf.extract(member, path=download_path)\n",
+    "                            (download_path / member.filename).rename(target_path)\n",
+    "\n",
     "                logger.info(f\"Extraído: {filename}\")\n",
     "            except zipfile.BadZipFile as bz:\n",
     "                logger.error(f\"Url: {url}, Error: {bz}, Message: Erro ao tentar descompactar o arquivo: {filename}\")\n",
@@ -192,8 +197,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 14:21:00,802 - INFO - Baixado: Lucro%20Presumido.zip\n",
-      "2025-08-22 14:21:01,750 - INFO - Extraído: Lucro%20Presumido.zip\n"
+      "2025-08-26 10:20:24,625 - INFO - Baixado: Lucro%20Presumido.zip\n",
+      "2025-08-26 10:20:25,535 - INFO - Extraído: Lucro%20Presumido.zip\n"
      ]
     }
    ],
@@ -233,7 +238,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 14:21:03,224 - INFO - Pasta 'download' removida com sucesso após upload.\n"
+      "2025-08-26 10:20:27,601 - INFO - Pasta 'download' removida com sucesso após upload.\n"
      ]
     }
    ],


### PR DESCRIPTION
### Alterações realizadas
- Ajusta a função de extração de arquivos ZIP para ignorar pastas internas
- Agora apenas os CSVs são processados

### Motivação
Evitar criação de pastas desnecessárias dentro do MinIO e garantir consistência de dados.
Quando foi executado o notebook da camada bronze, deu erro por causa dessa subpasta.