### PR TITLE
feat: adiciona ingestão de dados MDIC - camada landing

### DIFF
--- a/src/dags/mdic/municipio_ncm/src_lnd_mdic_municipio_ncm.py
+++ b/src/dags/mdic/municipio_ncm/src_lnd_mdic_municipio_ncm.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_municipio_ncm():
+
+    landing_mdic_municipio_ncm = PapermillOperator(
+        task_id="landing_mdic_municipio_ncm",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_municipio_ncm.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_municipio_ncm.set_downstream(bronze_mdic_municipio_ncm)
+
+
+mdic_municipio_ncm()

--- a/src/dags/mdic/municipio_ncm/tasks/landing/src_lnd_mdic_municipio_ncm_exportacao.ipynb
+++ b/src/dags/mdic/municipio_ncm/tasks/landing/src_lnd_mdic_municipio_ncm_exportacao.ipynb
@@ -1,0 +1,305 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:22:20,692 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2015_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2016_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2017_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2018_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2019_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2020_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2021_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2022_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2023_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2024_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/EXP_2025_MUN.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/municipio_ncm/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:22:20,784 - INFO - Iniciando downloads...\n",
+      "2025-08-29 12:22:24,588 - INFO - Baixado: EXP_2015_MUN.csv\n",
+      "2025-08-29 12:22:25,450 - INFO - Baixado: EXP_2016_MUN.csv\n",
+      "2025-08-29 12:22:25,717 - INFO - Baixado: EXP_2017_MUN.csv\n",
+      "2025-08-29 12:22:27,461 - INFO - Baixado: EXP_2018_MUN.csv\n",
+      "2025-08-29 12:22:29,547 - INFO - Baixado: EXP_2019_MUN.csv\n",
+      "2025-08-29 12:22:30,082 - INFO - Baixado: EXP_2020_MUN.csv\n",
+      "2025-08-29 12:22:31,129 - INFO - Baixado: EXP_2021_MUN.csv\n",
+      "2025-08-29 12:22:33,157 - INFO - Baixado: EXP_2022_MUN.csv\n",
+      "2025-08-29 12:22:35,472 - INFO - Baixado: EXP_2025_MUN.csv\n",
+      "2025-08-29 12:22:35,829 - INFO - Baixado: EXP_2024_MUN.csv\n",
+      "2025-08-29 12:22:35,908 - INFO - Baixado: EXP_2023_MUN.csv\n",
+      "2025-08-29 12:22:35,911 - INFO - Arquivos baixados: 11\n",
+      "2025-08-29 12:22:36,176 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2015_MUN.csv\n",
+      "2025-08-29 12:22:36,406 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2016_MUN.csv\n",
+      "2025-08-29 12:22:36,648 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2017_MUN.csv\n",
+      "2025-08-29 12:22:36,908 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2018_MUN.csv\n",
+      "2025-08-29 12:22:37,206 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2019_MUN.csv\n",
+      "2025-08-29 12:22:37,472 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2020_MUN.csv\n",
+      "2025-08-29 12:22:37,852 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2021_MUN.csv\n",
+      "2025-08-29 12:22:38,177 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2022_MUN.csv\n",
+      "2025-08-29 12:22:38,466 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2023_MUN.csv\n",
+      "2025-08-29 12:22:38,762 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2024_MUN.csv\n",
+      "2025-08-29 12:22:38,947 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/EXP_2025_MUN.csv\n",
+      "2025-08-29 12:22:39,147 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/municipio_ncm/tasks/landing/src_lnd_mdic_municipio_ncm_importacao.ipynb
+++ b/src/dags/mdic/municipio_ncm/tasks/landing/src_lnd_mdic_municipio_ncm_importacao.ipynb
@@ -1,0 +1,305 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:23:07,638 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2015_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2016_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2017_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2018_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2019_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2020_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2021_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2022_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2023_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2024_MUN.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/mun/IMP_2025_MUN.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/municipio_ncm/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:23:07,703 - INFO - Iniciando downloads...\n",
+      "2025-08-29 12:23:12,470 - INFO - Baixado: IMP_2016_MUN.csv\n",
+      "2025-08-29 12:23:13,049 - INFO - Baixado: IMP_2017_MUN.csv\n",
+      "2025-08-29 12:23:15,554 - INFO - Baixado: IMP_2015_MUN.csv\n",
+      "2025-08-29 12:23:18,484 - INFO - Baixado: IMP_2018_MUN.csv\n",
+      "2025-08-29 12:23:20,487 - INFO - Baixado: IMP_2019_MUN.csv\n",
+      "2025-08-29 12:23:22,734 - INFO - Baixado: IMP_2020_MUN.csv\n",
+      "2025-08-29 12:23:25,114 - INFO - Baixado: IMP_2021_MUN.csv\n",
+      "2025-08-29 12:23:30,390 - INFO - Baixado: IMP_2022_MUN.csv\n",
+      "2025-08-29 12:23:31,019 - INFO - Baixado: IMP_2023_MUN.csv\n",
+      "2025-08-29 12:23:32,128 - INFO - Baixado: IMP_2024_MUN.csv\n",
+      "2025-08-29 12:23:35,435 - INFO - Baixado: IMP_2025_MUN.csv\n",
+      "2025-08-29 12:23:35,438 - INFO - Arquivos baixados: 11\n",
+      "2025-08-29 12:23:35,703 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2015_MUN.csv\n",
+      "2025-08-29 12:23:36,059 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2016_MUN.csv\n",
+      "2025-08-29 12:23:36,381 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2017_MUN.csv\n",
+      "2025-08-29 12:23:37,638 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2018_MUN.csv\n",
+      "2025-08-29 12:23:37,813 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2019_MUN.csv\n",
+      "2025-08-29 12:23:38,881 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2020_MUN.csv\n",
+      "2025-08-29 12:23:40,161 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2021_MUN.csv\n",
+      "2025-08-29 12:23:41,272 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2022_MUN.csv\n",
+      "2025-08-29 12:23:42,377 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2023_MUN.csv\n",
+      "2025-08-29 12:23:43,543 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2024_MUN.csv\n",
+      "2025-08-29 12:23:44,176 - INFO - Arquivo enviado para MinIO: mdic/municipio_ncm/IMP_2025_MUN.csv\n",
+      "2025-08-29 12:23:44,446 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/municipios_estados/municipios_estados_estados/src_lnd_mdic_municipios_estados_estados.py
+++ b/src/dags/mdic/municipios_estados/municipios_estados_estados/src_lnd_mdic_municipios_estados_estados.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_municipios_estados_estados():
+
+    landing_mdic_municipio_estados_estados = PapermillOperator(
+        task_id="landing_mdic_municipio_estados_estados",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_municipio_estados_estados.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_municipio_estados_estados_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_municipio_estados_estados.set_downstream(bronze_mdic_municipio_estados_estados)
+
+
+mdic_municipios_estados_estados()

--- a/src/dags/mdic/municipios_estados/municipios_estados_estados/tasks/landing/src_lnd_mdic_estados.ipynb
+++ b/src/dags/mdic/municipios_estados/municipios_estados_estados/tasks/landing/src_lnd_mdic_estados.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:37:48,943 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/UF.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/municipios_estados_estados/\" \n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:37:49,014 - INFO - Iniciando downloads...\n",
+      "2025-08-29 12:37:49,403 - INFO - Baixado: UF.csv\n",
+      "2025-08-29 12:37:49,405 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 12:37:49,428 - INFO - Arquivo enviado para MinIO: mdic/municipios_estados_estados/UF.csv\n",
+      "2025-08-29 12:37:49,429 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/municipios_estados/municipios_estados_municipios/src_lnd_mdic_municipios_estados_municipios.py
+++ b/src/dags/mdic/municipios_estados/municipios_estados_municipios/src_lnd_mdic_municipios_estados_municipios.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_municipios_estados_municipios():
+
+    landing_mdic_municipios_estados_municipios = PapermillOperator(
+        task_id="landing_mdic_municipios_estados_municipios",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_municipios_estados_municipios.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_municipios_estados_municipios_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipios_estados_municipios = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipios_estados_municipios.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipios_estados_municipios_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_municipios_estados_municipios.set_downstream(bronze_mdic_municipios_estados_municipios)
+
+
+mdic_municipios_estados_municipios()

--- a/src/dags/mdic/municipios_estados/municipios_estados_municipios/tasks/landing/src_lnd_mdic_municipios_estados_municipios.ipynb
+++ b/src/dags/mdic/municipios_estados/municipios_estados_municipios/tasks/landing/src_lnd_mdic_municipios_estados_municipios.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:43:38,155 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/UF_MUN.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/municipios_estados_municipios/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:43:38,216 - INFO - Iniciando downloads...\n",
+      "2025-08-29 12:43:38,959 - INFO - Baixado: UF_MUN.csv\n",
+      "2025-08-29 12:43:38,961 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 12:43:38,985 - INFO - Arquivo enviado para MinIO: mdic/municipios_estados_municipios/UF_MUN.csv\n",
+      "2025-08-29 12:43:38,987 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/pais_ncm/src_lnd_mdic_pais_ncm.py
+++ b/src/dags/mdic/pais_ncm/src_lnd_mdic_pais_ncm.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_pais_ncm():
+
+    landing_mdic_pais_ncm = PapermillOperator(
+        task_id="landing_mdic_pais_ncm",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_pais_ncm.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_pais_ncm_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_pais_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_pais_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_pais_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_pais_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_pais_ncm.set_downstream(bronze_mdic_pais_ncm)
+
+
+mdic_pais_ncm()

--- a/src/dags/mdic/pais_ncm/tasks/landing/src_lnd_mdic_pais_ncm_exportacao.ipynb
+++ b/src/dags/mdic/pais_ncm/tasks/landing/src_lnd_mdic_pais_ncm_exportacao.ipynb
@@ -1,0 +1,305 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:53:55,841 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2015.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2016.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2017.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2018.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2019.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2020.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2021.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2022.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2023.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2024.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/EXP_2025.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/pais_ncm/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:53:55,899 - INFO - Iniciando downloads...\n",
+      "2025-08-29 12:54:02,875 - INFO - Baixado: EXP_2015.csv\n",
+      "2025-08-29 12:54:04,995 - INFO - Baixado: EXP_2017.csv\n",
+      "2025-08-29 12:54:05,850 - INFO - Baixado: EXP_2016.csv\n",
+      "2025-08-29 12:54:08,274 - INFO - Baixado: EXP_2018.csv\n",
+      "2025-08-29 12:54:13,851 - INFO - Baixado: EXP_2021.csv\n",
+      "2025-08-29 12:54:18,469 - INFO - Baixado: EXP_2019.csv\n",
+      "2025-08-29 12:54:20,427 - INFO - Baixado: EXP_2020.csv\n",
+      "2025-08-29 12:54:20,604 - INFO - Baixado: EXP_2022.csv\n",
+      "2025-08-29 12:54:24,632 - INFO - Baixado: EXP_2025.csv\n",
+      "2025-08-29 12:54:32,191 - INFO - Baixado: EXP_2023.csv\n",
+      "2025-08-29 12:54:34,968 - INFO - Baixado: EXP_2024.csv\n",
+      "2025-08-29 12:54:34,970 - INFO - Arquivos baixados: 11\n",
+      "2025-08-29 12:54:35,247 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2015.csv\n",
+      "2025-08-29 12:54:35,560 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2016.csv\n",
+      "2025-08-29 12:54:35,843 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2017.csv\n",
+      "2025-08-29 12:54:36,144 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2018.csv\n",
+      "2025-08-29 12:54:36,467 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2019.csv\n",
+      "2025-08-29 12:54:36,797 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2020.csv\n",
+      "2025-08-29 12:54:37,146 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2021.csv\n",
+      "2025-08-29 12:54:37,511 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2022.csv\n",
+      "2025-08-29 12:54:37,925 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2023.csv\n",
+      "2025-08-29 12:54:38,456 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2024.csv\n",
+      "2025-08-29 12:54:38,870 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/EXP_2025.csv\n",
+      "2025-08-29 12:54:39,160 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/pais_ncm/tasks/landing/src_lnd_mdic_pais_ncm_importacao.ipynb
+++ b/src/dags/mdic/pais_ncm/tasks/landing/src_lnd_mdic_pais_ncm_importacao.ipynb
@@ -1,0 +1,305 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:54:51,634 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2015.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2016.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2017.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2018.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2019.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2020.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2021.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2022.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2023.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2024.csv\",\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/comexstat-bd/ncm/IMP_2025.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/pais_ncm/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 12:54:51,694 - INFO - Iniciando downloads...\n",
+      "2025-08-29 12:55:03,223 - INFO - Baixado: IMP_2016.csv\n",
+      "2025-08-29 12:55:10,112 - INFO - Baixado: IMP_2015.csv\n",
+      "2025-08-29 12:55:10,459 - INFO - Baixado: IMP_2017.csv\n",
+      "2025-08-29 12:55:10,637 - INFO - Baixado: IMP_2018.csv\n",
+      "2025-08-29 12:55:20,747 - INFO - Baixado: IMP_2021.csv\n",
+      "2025-08-29 12:55:29,165 - INFO - Baixado: IMP_2020.csv\n",
+      "2025-08-29 12:55:30,490 - INFO - Baixado: IMP_2019.csv\n",
+      "2025-08-29 12:55:31,467 - INFO - Baixado: IMP_2022.csv\n",
+      "2025-08-29 12:55:36,934 - INFO - Baixado: IMP_2025.csv\n",
+      "2025-08-29 12:55:44,856 - INFO - Baixado: IMP_2023.csv\n",
+      "2025-08-29 12:55:46,880 - INFO - Baixado: IMP_2024.csv\n",
+      "2025-08-29 12:55:46,882 - INFO - Arquivos baixados: 11\n",
+      "2025-08-29 12:55:47,369 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2015.csv\n",
+      "2025-08-29 12:55:47,836 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2016.csv\n",
+      "2025-08-29 12:55:48,241 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2017.csv\n",
+      "2025-08-29 12:55:48,645 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2018.csv\n",
+      "2025-08-29 12:55:49,053 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2019.csv\n",
+      "2025-08-29 12:55:50,074 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2020.csv\n",
+      "2025-08-29 12:55:55,658 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2021.csv\n",
+      "2025-08-29 12:56:00,327 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2022.csv\n",
+      "2025-08-29 12:56:04,727 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2023.csv\n",
+      "2025-08-29 12:56:04,687 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2024.csv\n",
+      "2025-08-29 12:56:05,125 - INFO - Arquivo enviado para MinIO: mdic/pais_ncm/IMP_2025.csv\n",
+      "2025-08-29 12:56:05,587 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/paises_blocos/paises_blocos_blocos/src_lnd_mdic_paises_blocos_blocos.py
+++ b/src/dags/mdic/paises_blocos/paises_blocos_blocos/src_lnd_mdic_paises_blocos_blocos.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_paises_blocos_blocos():
+
+    landing_mdic_paises_blocos_blocos = PapermillOperator(
+        task_id="landing_mdic_paises_blocos_blocos",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_paises_blocos_blocos.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_paises_blocos_blocos_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_paises_blocos_blocos = PapermillOperator(
+    #     task_id="bronze_mdic_paises_blocos_blocos",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_paises_blocos_blocos.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_paises_blocos_blocos_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_paises_blocos_blocos.set_downstream(bronze_mdic_paises_blocos_blocos)
+
+
+mdic_paises_blocos_blocos()

--- a/src/dags/mdic/paises_blocos/paises_blocos_blocos/tasks/landing/src_lnd_mdic_blocos_blocos.ipynb
+++ b/src/dags/mdic/paises_blocos/paises_blocos_blocos/tasks/landing/src_lnd_mdic_blocos_blocos.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:09:32,805 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/PAIS_BLOCO.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/paises_blocos_paises/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:09:32,867 - INFO - Iniciando downloads...\n",
+      "2025-08-29 13:09:33,359 - INFO - Baixado: PAIS_BLOCO.csv\n",
+      "2025-08-29 13:09:33,361 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 13:09:33,383 - INFO - Arquivo enviado para MinIO: mdic/paises_blocos_paises/PAIS_BLOCO.csv\n",
+      "2025-08-29 13:09:33,384 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/paises_blocos/paises_blocos_paises/src_lnd_mdic_paises_blocos_paises.py
+++ b/src/dags/mdic/paises_blocos/paises_blocos_paises/src_lnd_mdic_paises_blocos_paises.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_paises_blocos_paises():
+
+    landing_mdic_paises_blocos_paises = PapermillOperator(
+        task_id="landing_mdic_paises_blocos_paises",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_paises_blocos_paises.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_paises_blocos_paises_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_paises_blocos_paises.set_downstream(bronze_mdic_paises_blocos_paises)
+
+
+mdic_paises_blocos_paises()

--- a/src/dags/mdic/paises_blocos/paises_blocos_paises/tasks/landing/src_lnd_mdic_paises_blocos_paises.ipynb
+++ b/src/dags/mdic/paises_blocos/paises_blocos_paises/tasks/landing/src_lnd_mdic_paises_blocos_paises.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:44:55,187 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/PAIS.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/paises_blocos_paises/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:44:55,256 - INFO - Iniciando downloads...\n",
+      "2025-08-29 13:44:55,739 - INFO - Baixado: PAIS.csv\n",
+      "2025-08-29 13:44:55,741 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 13:44:55,760 - INFO - Arquivo enviado para MinIO: mdic/paises_blocos_paises/PAIS.csv\n",
+      "2025-08-29 13:44:55,761 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_cgce/src_lnd_mdic_via_urf_urf.py
+++ b/src/dags/mdic/produtos/produtos_cgce/src_lnd_mdic_via_urf_urf.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_cgce():
+
+    landing_mdic_produtos_produtos_cgce = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_cgce",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_cgce.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_cgce_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_cgce.set_downstream(bronze_mdic_produtos_produtos_cgce)
+
+
+mdic_produtos_produtos_cgce()

--- a/src/dags/mdic/produtos/produtos_cgce/tasks/landing/src_lnd_mdic_produtos_produtos_cgce.ipynb
+++ b/src/dags/mdic/produtos/produtos_cgce/tasks/landing/src_lnd_mdic_produtos_produtos_cgce.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:58:29,839 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM_CGCE.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_cgce/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:58:29,900 - INFO - Iniciando downloads...\n",
+      "2025-08-29 13:58:30,281 - INFO - Baixado: NCM_CGCE.csv\n",
+      "2025-08-29 13:58:30,283 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 13:58:30,303 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_cgce/NCM_CGCE.csv\n",
+      "2025-08-29 13:58:30,304 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_cuci/src_lnd_mdic_produtos_produtos_cuci.py
+++ b/src/dags/mdic/produtos/produtos_cuci/src_lnd_mdic_produtos_produtos_cuci.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_cuci():
+
+    landing_mdic_produtos_produtos_cuci = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_cuci",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_cuci.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_cuci_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_cuci.set_downstream(bronze_mdic_produtos_produtos_cuci)
+
+
+mdic_produtos_produtos_cuci()

--- a/src/dags/mdic/produtos/produtos_cuci/tasks/landing/src_lnd_mdic_produtos_cuci.ipynb
+++ b/src/dags/mdic/produtos/produtos_cuci/tasks/landing/src_lnd_mdic_produtos_cuci.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:59:25,760 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM_CUCI.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_cuci/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:59:25,829 - INFO - Iniciando downloads...\n",
+      "2025-08-29 13:59:26,801 - INFO - Baixado: NCM_CUCI.csv\n",
+      "2025-08-29 13:59:26,802 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 13:59:26,834 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_cuci/NCM_CUCI.csv\n",
+      "2025-08-29 13:59:26,836 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_fa/src_lnd_mdic_produtos_produtos_fa.py
+++ b/src/dags/mdic/produtos/produtos_fa/src_lnd_mdic_produtos_produtos_fa.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_fa():
+
+    landing_mdic_produtos_produtos_fa = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_fa",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_fa.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_fa_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_fa.set_downstream(bronze_mdic_produtos_produtos_fa)
+
+
+mdic_produtos_produtos_fa()

--- a/src/dags/mdic/produtos/produtos_fa/tasks/landing/src_lnd_mdic_produtos_fa.ipynb
+++ b/src/dags/mdic/produtos/produtos_fa/tasks/landing/src_lnd_mdic_produtos_fa.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:02:13,677 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM_FAT_AGREG.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_fa/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:02:13,746 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:02:14,150 - INFO - Baixado: NCM_FAT_AGREG.csv\n",
+      "2025-08-29 14:02:14,152 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:02:14,172 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_fa/NCM_FAT_AGREG.csv\n",
+      "2025-08-29 14:02:14,174 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_isic/src_lnd_mdic_produtos_produtos_isic.py
+++ b/src/dags/mdic/produtos/produtos_isic/src_lnd_mdic_produtos_produtos_isic.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_via_urf_urf():
+
+    landing_mdic_via_urf_urf = PapermillOperator(
+        task_id="landing_mdic_via_urf_urf",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_via_urf_urf.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_via_urf_urf_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_via_urf_urf.set_downstream(bronze_mdic_via_urf_urf)
+
+
+mdic_via_urf_urf()

--- a/src/dags/mdic/produtos/produtos_isic/tasks/landing/src_lnd_mdic_produtos_produtos_isic.ipynb
+++ b/src/dags/mdic/produtos/produtos_isic/tasks/landing/src_lnd_mdic_produtos_produtos_isic.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:04:13,365 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM_ISIC.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_isic/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:04:13,433 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:04:14,200 - INFO - Baixado: NCM_ISIC.csv\n",
+      "2025-08-29 14:04:14,202 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:04:14,226 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_isic/NCM_ISIC.csv\n",
+      "2025-08-29 14:04:14,228 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_isicxcuci/src_lnd_mdic_produtos_produtos_isicxcuci.py
+++ b/src/dags/mdic/produtos/produtos_isicxcuci/src_lnd_mdic_produtos_produtos_isicxcuci.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_isicxcuci():
+
+    landing_mdic_produtos_produtos_isicxcuci = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_isicxcuci",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_isicxcuci.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_isicxcuci_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_isicxcuci.set_downstream(bronze_mdic_produtos_produtos_isicxcuci)
+
+
+mdic_produtos_produtos_isicxcuci()

--- a/src/dags/mdic/produtos/produtos_isicxcuci/tasks/landing/src_lnd_mdic_produtos_isicxcuci.ipynb
+++ b/src/dags/mdic/produtos/produtos_isicxcuci/tasks/landing/src_lnd_mdic_produtos_isicxcuci.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:06:02,469 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/ISIC_CUCI.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_isicxcuci/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:06:02,530 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:06:03,486 - INFO - Baixado: ISIC_CUCI.csv\n",
+      "2025-08-29 14:06:03,488 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:06:03,521 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_isicxcuci/ISIC_CUCI.csv\n",
+      "2025-08-29 14:06:03,523 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_nbmxncm/src_lnd_mdic_produtos_produtos_nbmxncm.py
+++ b/src/dags/mdic/produtos/produtos_nbmxncm/src_lnd_mdic_produtos_produtos_nbmxncm.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_nbmxncm():
+
+    landing_mdic_produtos_produtos_nbmxncm = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_nbmxncm",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_nbmxncm.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_nbmxncm_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_nbmxncm.set_downstream(bronze_mdic_produtos_produtos_nbmxncm)
+
+
+mdic_produtos_produtos_nbmxncm()

--- a/src/dags/mdic/produtos/produtos_nbmxncm/tasks/landing/src_lnd_mdic_produtos_nbmxncm.ipynb
+++ b/src/dags/mdic/produtos/produtos_nbmxncm/tasks/landing/src_lnd_mdic_produtos_nbmxncm.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:08:09,443 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NBM_NCM.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_nbmxncm/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:08:09,508 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:08:10,276 - INFO - Baixado: NBM_NCM.csv\n",
+      "2025-08-29 14:08:10,278 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:08:10,304 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_nbmxncm/NBM_NCM.csv\n",
+      "2025-08-29 14:08:10,305 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_ncm/src_lnd_mdic_produtos_produtos_ncm.py
+++ b/src/dags/mdic/produtos/produtos_ncm/src_lnd_mdic_produtos_produtos_ncm.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_ncm():
+
+    landing_mdic_produtos_produtos_ncm = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_ncm",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_ncm.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_ncm_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_ncm.set_downstream(bronze_mdic_produtos_produtos_ncm)
+
+
+mdic_produtos_produtos_ncm()

--- a/src/dags/mdic/produtos/produtos_ncm/tasks/landing/src_lnd_mdic_produtos_produtos_ncm.ipynb
+++ b/src/dags/mdic/produtos/produtos_ncm/tasks/landing/src_lnd_mdic_produtos_produtos_ncm.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:13:16,295 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_ncm/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:13:16,381 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:13:17,520 - INFO - Baixado: NCM.csv\n",
+      "2025-08-29 14:13:17,521 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:13:17,568 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_ncm/NCM.csv\n",
+      "2025-08-29 14:13:17,572 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_ppe/src_lnd_mdic_produtos_produtos_ppe.py
+++ b/src/dags/mdic/produtos/produtos_ppe/src_lnd_mdic_produtos_produtos_ppe.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_ppe():
+
+    landing_mdic_produtos_produtos_ppe = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_ppe",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_ppe.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_ppe_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_ppe.set_downstream(bronze_mdic_produtos_produtos_ppe)
+
+
+mdic_produtos_produtos_ppe()

--- a/src/dags/mdic/produtos/produtos_ppe/tasks/landing/src_lnd_mdic_produtos_ppe.ipynb
+++ b/src/dags/mdic/produtos/produtos_ppe/tasks/landing/src_lnd_mdic_produtos_ppe.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:17:45,400 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM_PPE.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_ppe/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:17:45,462 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:17:46,025 - INFO - Baixado: NCM_PPE.csv\n",
+      "2025-08-29 14:17:46,027 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:17:46,049 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_ppe/NCM_PPE.csv\n",
+      "2025-08-29 14:17:46,050 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_ppi/src_lnd_mdic_produtos_produtos_ppi.py
+++ b/src/dags/mdic/produtos/produtos_ppi/src_lnd_mdic_produtos_produtos_ppi.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_ppi():
+
+    landing_mdic_produtos_produtos_ppi = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_ppi",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_ppi.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_ppi_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_ppi.set_downstream(bronze_mdic_produtos_produtos_ppi)
+
+
+mdic_produtos_produtos_ppi()

--- a/src/dags/mdic/produtos/produtos_ppi/tasks/landing/src_lnd_mdic_produtos_ppi.ipynb
+++ b/src/dags/mdic/produtos/produtos_ppi/tasks/landing/src_lnd_mdic_produtos_ppi.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:20:16,567 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM_PPI.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_ppi/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:20:16,639 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:20:17,205 - INFO - Baixado: NCM_PPI.csv\n",
+      "2025-08-29 14:20:17,207 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:20:17,228 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_ppi/NCM_PPI.csv\n",
+      "2025-08-29 14:20:17,230 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_sh/src_lnd_mdic_produtos_produtos_sh.py
+++ b/src/dags/mdic/produtos/produtos_sh/src_lnd_mdic_produtos_produtos_sh.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_sh():
+
+    landing_mdic_produtos_produtos_sh = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_sh",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_sh.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_sh_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_sh.set_downstream(bronze_mdic_produtos_produtos_sh)
+
+
+mdic_produtos_produtos_sh()

--- a/src/dags/mdic/produtos/produtos_sh/tasks/landing/src_lnd_mdic_produtos_sh.ipynb
+++ b/src/dags/mdic/produtos/produtos_sh/tasks/landing/src_lnd_mdic_produtos_sh.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:23:20,629 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM_SH.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_sh/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:23:20,692 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:23:22,182 - INFO - Baixado: NCM_SH.csv\n",
+      "2025-08-29 14:23:22,184 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:23:22,260 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_sh/NCM_SH.csv\n",
+      "2025-08-29 14:23:22,265 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/produtos/produtos_uencm/src_lnd_mdic_produtos_produtos_uencm.py
+++ b/src/dags/mdic/produtos/produtos_uencm/src_lnd_mdic_produtos_produtos_uencm.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_produtos_produtos_uencm():
+
+    landing_mdic_produtos_produtos_uencm = PapermillOperator(
+        task_id="landing_mdic_produtos_produtos_uencm",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_produtos_produtos_uencm.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_produtos_produtos_uencm_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_produtos_produtos_uencm.set_downstream(bronze_mdic_produtos_produtos_uencm)
+
+
+mdic_produtos_produtos_uencm()

--- a/src/dags/mdic/produtos/produtos_uencm/tasks/landing/src_lnd_mdic_produtos_produtos_uencm.ipynb
+++ b/src/dags/mdic/produtos/produtos_uencm/tasks/landing/src_lnd_mdic_produtos_produtos_uencm.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:34:33,992 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/NCM_UNIDADE.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/produtos_produtos_uencm/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 14:34:34,054 - INFO - Iniciando downloads...\n",
+      "2025-08-29 14:34:34,433 - INFO - Baixado: NCM_UNIDADE.csv\n",
+      "2025-08-29 14:34:34,435 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 14:34:34,454 - INFO - Arquivo enviado para MinIO: mdic/produtos_produtos_uencm/NCM_UNIDADE.csv\n",
+      "2025-08-29 14:34:34,455 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/via_urf/via_urf_urf/src_lnd_mdic_via_urf_urf.py
+++ b/src/dags/mdic/via_urf/via_urf_urf/src_lnd_mdic_via_urf_urf.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_via_urf_urf():
+
+    landing_mdic_via_urf_urf = PapermillOperator(
+        task_id="landing_mdic_via_urf_urf",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_via_urf_urf.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_via_urf_urf_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_via_urf_urf.set_downstream(bronze_mdic_via_urf_urf)
+
+
+mdic_via_urf_urf()

--- a/src/dags/mdic/via_urf/via_urf_urf/tasks/landing/src_lnd_mdic_via_urf_urf.ipynb
+++ b/src/dags/mdic/via_urf/via_urf_urf/tasks/landing/src_lnd_mdic_via_urf_urf.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:15:42,775 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/URF.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/via_urf_urf/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:15:42,844 - INFO - Iniciando downloads...\n",
+      "2025-08-29 13:15:43,259 - INFO - Baixado: URF.csv\n",
+      "2025-08-29 13:15:43,260 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 13:15:43,281 - INFO - Arquivo enviado para MinIO: mdic/via_urf_urf/URF.csv\n",
+      "2025-08-29 13:15:43,282 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/mdic/via_urf/via_urf_via/src_lnd_mdic_via_urf_via.py
+++ b/src/dags/mdic/via_urf/via_urf_via/src_lnd_mdic_via_urf_via.py
@@ -1,0 +1,45 @@
+import os
+
+import pendulum
+from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.sdk import Variable, dag
+
+
+@dag(
+    schedule="*/3 * * * *",
+    start_date=pendulum.datetime(2025, 1, 1, tz="America/Maceio"),
+    catchup=False,
+    tags=["pyspark", "delta", "minio"],
+)
+def mdic_via_urf_via():
+
+    landing_mdic_via_urf_via = PapermillOperator(
+        task_id="landing_mdic_via_urf_via",
+        input_nb=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "tasks", 
+            "landing", 
+            "src_lnd_mdic_via_urf_via.ipynb",
+        ),
+        output_nb="/opt/airflow/logs/tasks/landing/src_lnd_mdic_via_urf_via_{{ ts_nodash }}.ipynb",
+        parameters={"minio_connection": Variable.get("minio_connection")}
+    )
+
+
+
+    # bronze_mdic_municipio_ncm = PapermillOperator(
+    #     task_id="bronze_mdic_municipio_ncm",
+    #     input_nb=os.path.join(
+    #         os.path.dirname(os.path.realpath(__file__)), 
+    #         "tasks", 
+    #         "bronze",
+    #         "lnd_brz_mdic_municipio_ncm.ipynb"
+    #     ),
+    #     output_nb="/opt/airflow/logs/tasks/bronze/lnd_brz_mdic_municipio_ncm_{{ ts_nodash }}.ipynb",
+    #     parameters={"minio_connection": Variable.get("minio_connection")}
+    # )
+
+    landing_mdic_via_urf_via.set_downstream(bronze_mdic_via_urf_via)
+
+
+mdic_via_urf_via()

--- a/src/dags/mdic/via_urf/via_urf_via/tasks/landing/src_lnd_mdic_via_urf_via.ipynb
+++ b/src/dags/mdic/via_urf/via_urf_via/tasks/landing/src_lnd_mdic_via_urf_via.ipynb
@@ -1,0 +1,275 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "dd50ec60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aiohttp\n",
+    "import asyncio\n",
+    "import os\n",
+    "import json\n",
+    "import logging\n",
+    "from pathlib import Path\n",
+    "import logging\n",
+    "\n",
+    "from minio import Minio\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7681ecd0",
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "minio_connection = \"\"  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42216f90",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Configuração básica de logging\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO, format=\"%(asctime)s - %(levelname)s - %(message)s\"\n",
+    ")\n",
+    "\n",
+    "logger = logging.getLogger(__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7401866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# carregar para funcionar\n",
+    "try:\n",
+    "    minio_conn = json.loads(minio_connection)\n",
+    "except json.JSONDecodeError:\n",
+    "    with open('../variables/minio_connection.json', \"r\") as minio_connection_file:\n",
+    "        minio_conn = json.loads(minio_connection_file.read())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8e112eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:25:22,178 - INFO - Cliente MinIO criado com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "s3_client = None\n",
+    "\n",
+    "try:\n",
+    "    endpoint_raw = minio_conn[\"endpoint\"]\n",
+    "    access_key = minio_conn[\"access_key\"]\n",
+    "    secret_key = minio_conn[\"key\"]\n",
+    "\n",
+    "    endpoint_sem_http = endpoint_raw.replace(\"http://\", \"\").replace(\"https://\", \"\")\n",
+    "    is_secure = endpoint_raw.startswith(\"https\")\n",
+    "\n",
+    "    s3_client = Minio(\n",
+    "        endpoint=endpoint_sem_http,\n",
+    "        access_key=access_key,\n",
+    "        secret_key=secret_key,\n",
+    "        secure=is_secure\n",
+    "    )\n",
+    "\n",
+    "    logging.info(\"Cliente MinIO criado com sucesso.\")\n",
+    "\n",
+    "except KeyError as e:\n",
+    "    logging.error(f\"Erro de configuração: chave ausente - {e}\")\n",
+    "except Exception as e:\n",
+    "    logging.error(f\"Erro ao inicializar o cliente MinIO: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "361ee61a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "urls = [\n",
+    "    \"https://balanca.economia.gov.br/balanca/bd/tabelas/VIA.csv\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1aff072",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controle de concorrência (None = sem limite)\n",
+    "MAX_CONCURRENT_DOWNLOADS = 3\n",
+    "\n",
+    "sem = asyncio.Semaphore(MAX_CONCURRENT_DOWNLOADS) if MAX_CONCURRENT_DOWNLOADS else None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ccdecd4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bucket = \"landing\"\n",
+    "caminho_destino = \"mdic/via_urf_via/\"\n",
+    "download_dir = \"download\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "22df2ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def _download(session: aiohttp.ClientSession, url: str, retries: int):\n",
+    "    \"\"\"Baixa um arquivo com retries e tratamento de erros\"\"\"\n",
+    "    for tentativa in range(1, retries + 1):\n",
+    "        try:\n",
+    "            timeout = aiohttp.ClientTimeout(total=600)\n",
+    "            async with session.get(url, timeout=timeout) as response:\n",
+    "                status = response.status\n",
+    "                if status != 200:\n",
+    "                    logger.error(f\"Url: {url}, Status: {status}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_type = response.headers.get(\"Content-Type\", \"\")\n",
+    "                if \"text/csv\" not in content_type and \"application/octet-stream\" not in content_type:\n",
+    "                    logger.error(f\"Url: {url}, Tipo inesperado: {content_type}\")\n",
+    "                    return None\n",
+    "\n",
+    "                content_length = response.headers.get(\"Content-Length\")\n",
+    "                if content_length is None or int(content_length) == 0:\n",
+    "                    logger.error(f\"Url: {url}, Tamanho indefinido ou zero\")\n",
+    "                    return None\n",
+    "\n",
+    "                filename = url.split(\"/\")[-1]\n",
+    "                path_file = os.path.join(download_dir, filename)\n",
+    "                with open(path_file, \"wb\") as f:\n",
+    "                    async for chunk in response.content.iter_chunked(1024*1024):\n",
+    "                        f.write(chunk)\n",
+    "\n",
+    "                logger.info(f\"Baixado: {filename}\")\n",
+    "                return filename\n",
+    "\n",
+    "        except Exception as e:\n",
+    "            logger.warning(f\"Tentativa {tentativa}/{retries} falhou para {url}: {e}\")\n",
+    "            await asyncio.sleep(5)\n",
+    "    return False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "2a031bd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "async def fetch(session: aiohttp.ClientSession, url: str):\n",
+    "    \"\"\"Orquestra o download com semáforo\"\"\"\n",
+    "    if sem:\n",
+    "        async with sem:\n",
+    "            return await _download(session, url, retries=3)\n",
+    "    else:\n",
+    "        return await _download(session, url, retries=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "24153c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:25:22,237 - INFO - Iniciando downloads...\n",
+      "2025-08-29 13:25:22,741 - INFO - Baixado: VIA.csv\n",
+      "2025-08-29 13:25:22,743 - INFO - Arquivos baixados: 1\n",
+      "2025-08-29 13:25:22,761 - INFO - Arquivo enviado para MinIO: mdic/via_urf_via/VIA.csv\n",
+      "2025-08-29 13:25:22,763 - INFO - Pasta 'download' removida com sucesso.\n"
+     ]
+    }
+   ],
+   "source": [
+    "async def main():\n",
+    "    os.makedirs(download_dir, exist_ok=True)\n",
+    "    logger.info(\"Iniciando downloads...\")\n",
+    "\n",
+    "    async with aiohttp.ClientSession() as session:\n",
+    "        tasks = [fetch(session, url) for url in urls]\n",
+    "        results = await asyncio.gather(*tasks)\n",
+    "\n",
+    "    arquivos_csv = [Path(download_dir) / r for r in results if r]\n",
+    "    logger.info(f\"Arquivos baixados: {len(arquivos_csv)}\")\n",
+    "\n",
+    "    # Upload para MinIO\n",
+    "    for arquivo in arquivos_csv:\n",
+    "        caminho_relativo = arquivo.relative_to(download_dir)\n",
+    "        destino = f\"{caminho_destino}{caminho_relativo.as_posix()}\"\n",
+    "        s3_client.fput_object(\n",
+    "            bucket_name=bucket,\n",
+    "            object_name=destino,\n",
+    "            file_path=str(arquivo)\n",
+    "        )\n",
+    "        logger.info(f\"Arquivo enviado para MinIO: {destino}\")\n",
+    "\n",
+    "    # Limpeza da pasta\n",
+    "    try:\n",
+    "        shutil.rmtree(download_dir)\n",
+    "        logger.info(f\"Pasta '{download_dir}' removida com sucesso.\")\n",
+    "    except Exception as e:\n",
+    "        logger.error(f\"Erro ao remover pasta '{download_dir}': {e}\")\n",
+    "\n",
+    "await main()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "projeto-lakehouse (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_presumido.ipynb
+++ b/src/dags/rfb/regime_tributario/tasks/landing/src_lnd_rfb_regime_tributario_lucro_presumido.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "acd7da26",
+   "id": "eac6017d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +72,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 14:20:38,597 - INFO - Cliente MinIO criado com sucesso.\n"
+      "2025-08-26 10:19:59,784 - INFO - Cliente MinIO criado com sucesso.\n"
      ]
     }
    ],
@@ -112,7 +112,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 14:20:38,615 - INFO - Pasta de download criada: download\n"
+      "2025-08-26 10:19:59,797 - INFO - Pasta de download criada: download\n"
      ]
     }
    ],
@@ -171,7 +171,12 @@
     "            # Extração\n",
     "            try:\n",
     "                with zipfile.ZipFile(path_file, \"r\") as zf:\n",
-    "                    zf.extractall(download_path)\n",
+    "                    for member in zf.infolist():\n",
+    "                        if member.filename.endswith(\".csv\"):\n",
+    "                            target_path = download_path / Path(member.filename).name\n",
+    "                            zf.extract(member, path=download_path)\n",
+    "                            (download_path / member.filename).rename(target_path)\n",
+    "\n",
     "                logger.info(f\"Extraído: {filename}\")\n",
     "            except zipfile.BadZipFile as bz:\n",
     "                logger.error(f\"Url: {url}, Error: {bz}, Message: Erro ao tentar descompactar o arquivo: {filename}\")\n",
@@ -192,8 +197,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 14:21:00,802 - INFO - Baixado: Lucro%20Presumido.zip\n",
-      "2025-08-22 14:21:01,750 - INFO - Extraído: Lucro%20Presumido.zip\n"
+      "2025-08-26 10:20:24,625 - INFO - Baixado: Lucro%20Presumido.zip\n",
+      "2025-08-26 10:20:25,535 - INFO - Extraído: Lucro%20Presumido.zip\n"
      ]
     }
    ],
@@ -233,7 +238,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-08-22 14:21:03,224 - INFO - Pasta 'download' removida com sucesso após upload.\n"
+      "2025-08-26 10:20:27,601 - INFO - Pasta 'download' removida com sucesso após upload.\n"
      ]
     }
    ],


### PR DESCRIPTION
### 📌 Descrição
Este PR adiciona o script de ingestão dos arquivos do MDIC na camada landing.

### Alterações
- Criação do script ingestao_mdic_landing, onde a estrutura de dados foram divididas por blocos:
-- Bloco 1 - Municipio por NCM
-- Bloco 2 – Municípios e Estados
-- Bloco 3 – Países por NCM
-- Bloco 4 – Países e blocos econômicos
-- Bloco 5 – Produtos
-- Bloco 6 – Vias de transporte e URF
- Script principal de ingestão .py
- Configuração inicial da DAG de ingestão 
- arquivo de variáveis e parâmetros reutilizáveis
- Dados salvos na camada landing do datalake